### PR TITLE
Remove SettingsViewModel from MainViewModel

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
@@ -14,9 +14,6 @@ public partial class MainViewModel : ObservableObject
 	private ObservableCollection<Twin> _devices = [];
 
 	[ObservableProperty]
-	private SettingsViewModel _settingsViewModel;
-
-	[ObservableProperty]
 	private Twin _selectedDevice;
 
 	public async Task SetDevicesAsync()
@@ -52,8 +49,6 @@ public partial class MainViewModel : ObservableObject
 	public MainViewModel(DeviceManager deviceManager)
 	{
 		_deviceManager = deviceManager;
-
-		_settingsViewModel = new SettingsViewModel(deviceManager);
 
 		Task.Run(SetDevicesAsync);
 	}


### PR DESCRIPTION
Removed the SettingsViewModel property and its initialization from the MainViewModel class. This refactor likely changes how settings are managed within the application. The asynchronous device setup with Task.Run(SetDevicesAsync) in the constructor remains unchanged.