### PR TITLE
Update method name from ToggleTemperature to UpdateTemperature

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -133,7 +133,7 @@ public partial class DeviceDetailViewModel : ObservableObject
 	{
 		try
 		{
-			var result = await _deviceManager.InvokeDirectMethodAsync(DeviceId, "ToggleTemperature");
+			var result = await _deviceManager.InvokeDirectMethodAsync(DeviceId, "UpdateTemperature");
 
 			if (result != null && result.Status == 200)
 			{


### PR DESCRIPTION
Changed the invoked method name in ToggleTemperatureStateAsync from "ToggleTemperature" to "UpdateTemperature" to align with the updated API. The rest of the method logic remains unchanged.