### PR TITLE
Refactor SettingsPage layout and styling

### DIFF
--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
@@ -4,58 +4,69 @@
              x:Class="SmartHomeMauiApp.MVVM.Views.SettingsPage"
              xmlns:viewModels="clr-namespace:SmartHomeMauiApp.MVVM.ViewModels"
              x:DataType="{x:Type viewModels:SettingsViewModel}"
-             NavigationPage.HasNavigationBar="False">
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="#0f0f0f">
 
-    <ContentPage.Resources>
-        <Style x:Key="LabelStyle"
-               TargetType="Label">
-            <Setter Property="FontSize"
-                    Value="16" />
-            <Setter Property="TextColor"
-                    Value="#666666" />
-            <Setter Property="Margin"
-                    Value="0,10,0,5" />
-        </Style>
+    <!-- Main Grid Layout -->
+    <Grid>
+        <!-- Background Image -->
+        <Image Source="maui_background.png"
+               Aspect="AspectFill"
+               Opacity="0.2" />
 
-        <Style x:Key="EntryStyle"
-               TargetType="Entry">
-            <Setter Property="TextColor"
-                    Value="#333333" />
-            <Setter Property="Margin"
-                    Value="0,5,0,15" />
-            <Setter Property="HeightRequest"
-                    Value="40" />
-        </Style>
+        <!-- Main Content -->
+        <ScrollView>
+            <StackLayout Padding="30"
+                         Spacing="20"
+                         VerticalOptions="CenterAndExpand"
+                         HorizontalOptions="CenterAndExpand"
+                         BackgroundColor="Transparent">
 
-    </ContentPage.Resources>
+                <!-- Home Button -->
+                <Button Text="&#xf015;"
+                        FontSize="18"
+                        FontFamily="fa-solid"
+                        Margin="0,10,0,0"
+                        Command="{Binding NavigateHomeCommand}"
+                        HorizontalOptions="Start"/>
 
-    <Grid RowDefinitions="auto, auto"
-          Margin="30">
+                <!-- Title -->
+                <Label Text="Settings"
+                       FontSize="Large"
+                       FontAttributes="Bold"
+                       HorizontalOptions="Center"
+                       TextColor="White" />
 
-        <Button Grid.Row="0"
-                Text="&#xf015;"
-                FontSize="18"
-                FontFamily="fa-solid"
-                Command="{Binding NavigateHomeCommand}"
-                HorizontalOptions="Start" />
+                <!-- Connection String -->
+                <Label Text="Connection String:"
+                       FontSize="16"
+                       TextColor="White"
+                       Margin="0,10,0,5" />
+                <Entry Text="{Binding ConnectionString, Mode=TwoWay}"
+                       TextColor="White"
+                       BackgroundColor="#333333"
+                       Margin="0,5,0,15"
+                       HeightRequest="40" />
 
-        <StackLayout Grid.Row="1"
-                     Padding="20"
-                     Spacing="10">
+                <!-- Email Address -->
+                <Label Text="Email Address for Notifications:"
+                       FontSize="16"
+                       TextColor="White"
+                       Margin="0,10,0,5" />
+                <Entry Text="{Binding EmailAddress, Mode=TwoWay}"
+                       TextColor="White"
+                       BackgroundColor="#333333"
+                       Margin="0,5,0,15"
+                       HeightRequest="40" />
 
-            <Label Text="Connection String:"
-                   Style="{StaticResource LabelStyle}" />
-            <Entry Text="{Binding ConnectionString, Mode=TwoWay}"
-                   Style="{StaticResource EntryStyle}" />
-
-            <Label Text="Email Address for Notifications:"
-                   Style="{StaticResource LabelStyle}" />
-            <Entry Text="{Binding EmailAddress, Mode=TwoWay}"
-                   Style="{StaticResource EntryStyle}" />
-
-            <Button Text="Save Settings"
-                    Command="{Binding SaveSettingsCommand}" />
-        </StackLayout>
-
+                <!-- Save Settings Button -->
+                <Button Text="Save Settings"
+                        Command="{Binding SaveSettingsCommand}"
+                        BackgroundColor="DodgerBlue"
+                        TextColor="White"
+                        HorizontalOptions="FillAndExpand"
+                        CornerRadius="10" />
+            </StackLayout>
+        </ScrollView>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
Updated SettingsPage.xaml to enhance UI/UX:
- Changed `ContentPage` background color to `#0f0f0f`.
- Removed `ContentPage.Resources` section with `Label` and `Entry` styles.
- Introduced a new `Grid` layout with a background `Image` (source: `maui_background.png`, opacity: `0.2`).
- Wrapped main content in a `ScrollView` containing a `StackLayout` with padding, spacing, and transparent background.
- Added a home navigation `Button` with specific styling and command binding.
- Added a styled `Label` for the page title "Settings".
- Added "Connection String" and "Email Address for Notifications" labels and entry fields with updated styling.
- Added a "Save Settings" button with specific styling.
- Removed the previous `Grid` layout and `StackLayout` containing the connection string, email address fields, and save button.