### PR TITLE
Add error handling to AddDeviceAsync method

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.Input;
 using Shared.Library.Services;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace SmartHomeMauiApp.MVVM.ViewModels;
 
@@ -40,17 +41,25 @@ public partial class AddDeviceViewModel : ObservableObject
             return;
         }
 
-        var response = await _deviceManager.AddDeviceAsync(DeviceId, SelectedDeviceType);
+        try
+        {
+            var response = await _deviceManager.AddDeviceAsync(DeviceId, SelectedDeviceType);
 
-        if (response.Succeeded)
-        {
-            ResponseMessage = response.Message ?? "Device added successfully.";
-            await _mainViewModel.SetDevicesAsync();
-            await Shell.Current.GoToAsync("//MainPage");
+            if (response.Succeeded)
+            {
+                ResponseMessage = response.Message ?? "Device added successfully.";
+                await _mainViewModel.SetDevicesAsync();
+                await Shell.Current.GoToAsync("//MainPage");
+            }
+            else
+            {
+                ResponseMessage = "Failed to add the device. It may already exist.";
+            }
         }
-        else
+        catch (Exception ex)
         {
-            ResponseMessage = response.Message ?? "Failed to add the device. It may already exist.";
+            ResponseMessage = $"An error occurred: {ex.Message}";
+            Debug.WriteLine($"Error in AddDeviceAsync: {ex}");
         }
     }
 


### PR DESCRIPTION
Updated `using` directives to include `System.Diagnostics`. Refactored `AddDeviceAsync` in `AddDeviceViewModel` to include a `try-catch` block for improved error handling. The `try` block attempts to add a device and updates the UI accordingly. The `catch` block logs exceptions and sets the response message to include the exception details, enhancing robustness and user feedback.