### PR TITLE
Rename SetDevicesAsync to LoadDevicesAsync in ViewModels

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
@@ -48,7 +48,7 @@ public partial class AddDeviceViewModel : ObservableObject
             if (response.Succeeded)
             {
                 ResponseMessage = response.Message ?? "Device added successfully.";
-                await _mainViewModel.SetDevicesAsync();
+                await _mainViewModel.LoadDevicesAsync();
                 await Shell.Current.GoToAsync("//MainPage");
             }
             else

--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -273,7 +273,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             }
 
             ResponseMessage = response.Message ?? $"Device {DeviceId} removed successfully.";
-            await _mainViewModel.SetDevicesAsync();
+            await _mainViewModel.LoadDevicesAsync();
             await Shell.Current.GoToAsync($"///MainPage");
         }
         catch (Exception ex)

--- a/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
@@ -30,10 +30,10 @@ public partial class MainViewModel : ObservableObject
 
         ResponseMessage = string.Empty;
 
-        Task.Run(SetDevicesAsync);
+        Task.Run(LoadDevicesAsync);
     }
 
-    public async Task SetDevicesAsync()
+    public async Task LoadDevicesAsync()
     {
         var response = await _deviceManager.GetDevicesAsync("SELECT * FROM devices");
 


### PR DESCRIPTION
Renamed the method `SetDevicesAsync` to `LoadDevicesAsync` across multiple ViewModel classes for better clarity and consistency.

Changes include:
- `AddDeviceViewModel.cs`: Updated method call after adding a device.
- `DeviceDetailViewModel.cs`: Updated method call after removing a device.
- `MainViewModel.cs`: Renamed method and updated initial call in the constructor.