### PR TITLE
Remove unused System.Text directive from DeviceManager.cs

### DIFF
--- a/Shared.Library/Services/DeviceManager.cs
+++ b/Shared.Library/Services/DeviceManager.cs
@@ -6,7 +6,6 @@ using Microsoft.Azure.Devices.Shared;
 using Newtonsoft.Json;
 using Shared.Library.Models;
 using System.Diagnostics;
-using System.Text;
 
 namespace Shared.Library.Services;
 


### PR DESCRIPTION
The `using System.Text;` directive was removed from the `DeviceManager.cs` file. This indicates that the `System.Text` namespace is no longer needed in this file, possibly because the code that required it has been refactored or removed.