### PR TITLE
Remove Swedish comment from DeviceRegistration class

### DIFF
--- a/AzureFunctions/Functions/DeviceRegistration.cs
+++ b/AzureFunctions/Functions/DeviceRegistration.cs
@@ -80,6 +80,4 @@ public class DeviceRegistration
             return new StatusCodeResult(StatusCodes.Status500InternalServerError);
         }
     }
-
-    //Lägg till function för att radera en enhet också o koppla in den
 }


### PR DESCRIPTION
Removed a comment in the `DeviceRegistration` class in `DeviceRegistration.cs` that was in Swedish, which suggested adding a function to delete a device and connect it.