### PR TITLE
Add Swedish comment about device removal bug

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -65,6 +65,7 @@ public partial class DeviceDetailViewModel : ObservableObject
 
         LoadUserSettings();
 
+        //FIXA VID BORTTAGNING OM EN ENHET INTE LÄNGRE EXISTERAR, BUG
         _updateTimer = new System.Timers.Timer(5000);
         _updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId);
         _updateTimer.Start();


### PR DESCRIPTION
A comment was added to the `DeviceDetailViewModel` class in the `DeviceDetailViewModel.cs` file. The comment, written in Swedish, mentions fixing a bug related to the removal of a device that no longer exists. The comment translates to "FIX WHEN REMOVING IF A DEVICE NO LONGER EXISTS, BUG," serving as a reminder for future development to address this issue.