### PR TITLE
Add stop method invocation before device disconnect

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -152,6 +152,14 @@ public partial class DeviceDetailViewModel : ObservableObject
     {
         try
         {
+            var stopResponse = await _deviceManager.InvokeDirectMethodAsync(DeviceId, "stop");
+            if (!stopResponse.Succeeded || stopResponse.Content is not CloudToDeviceMethodResult stopResult || stopResult.Status != 200)
+            {
+                ResponseMessage = "Failed to stop the device before disconnecting.";
+                Debug.WriteLine($"Error in DisconnectAsync: {stopResponse.Message}");
+                return;
+            }
+
             var response = await _deviceManager.InvokeDirectMethodAsync(DeviceId, "disconnect");
 
             if (response.Succeeded && response.Content is CloudToDeviceMethodResult result && result.Status == 200)


### PR DESCRIPTION
The `DisconnectAsync` method in `DeviceDetailViewModel` now includes an additional step to invoke a "stop" direct method on the device using `_deviceManager.InvokeDirectMethodAsync(DeviceId, "stop")` before disconnecting. If the "stop" method fails, an error message is set, and the method returns early. This change ensures the device is properly stopped before disconnection, enhancing safety and robustness.