### PR TITLE
Allow null values for several fields, make _timer readonly

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
@@ -27,18 +27,18 @@ public partial class MainViewModel : ObservableObject
     private Twin? _selectedDevice;
 
     [ObservableProperty]
-    private string _responseMessage;
+    private string? _responseMessage;
 
     [ObservableProperty]
-    private string weatherIcon;
+    private string? _weatherIcon;
 
     [ObservableProperty]
-    private string temperature;
+    private string? _temperature;
 
     [ObservableProperty]
-    private string conditionText;
+    private string? _conditionText;
 
-    private System.Timers.Timer _timer;
+    private readonly System.Timers.Timer _timer;
 
     public MainViewModel(DeviceManager deviceManager, DbContext dbContext)
     {


### PR DESCRIPTION
Changed the types of _responseMessage, weatherIcon, temperature, and conditionText fields from string to string? to allow null values. Made the _timer field readonly to ensure its reference cannot be changed after initialization.