### PR TITLE
Rename RemoveDeviceAsync to DeviceRemovalSendEmailAsync

### DIFF
--- a/Shared.Library/Services/DeviceManager.cs
+++ b/Shared.Library/Services/DeviceManager.cs
@@ -156,7 +156,7 @@ public class DeviceManager
         }
     }
 
-    public async Task<ResponseResult> RemoveDeviceAsync(string deviceId, string emailAddress)
+    public async Task<ResponseResult> DeviceRemovalSendEmailAsync(string deviceId, string emailAddress)
     {
         if (string.IsNullOrWhiteSpace(emailAddress) || string.IsNullOrEmpty(deviceId))
             return new ResponseResult { Succeeded = false, Message = "Email address and device id cannot be empty." };

--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -281,7 +281,7 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             _isRemovingDevice = true;
 
-            var response = await _deviceManager.RemoveDeviceAsync(DeviceId, EmailAddress);
+            var response = await _deviceManager.DeviceRemovalSendEmailAsync(DeviceId, EmailAddress);
 
             await Application.Current!.MainPage!.DisplayAlert(
             "Success",


### PR DESCRIPTION
Renamed the method `RemoveDeviceAsync` in `DeviceManager.cs` to `DeviceRemovalSendEmailAsync` to better reflect its functionality of removing a device and sending an email confirmation. Updated the corresponding method call in `DeviceDetailViewModel.cs` to use the new method name.