### PR TITLE
Make connection string, email, and response nullable

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
@@ -13,13 +13,13 @@ public partial class SettingsViewModel : ObservableObject
     private readonly DbContext _dbContext;
 
     [ObservableProperty]
-    private string _connectionString;
+    private string? _connectionString;
 
     [ObservableProperty]
-    private string _emailAddress;
+    private string? _emailAddress;
 
     [ObservableProperty]
-    private string _responseMessage;
+    private string? _responseMessage;
 
     public SettingsViewModel(DeviceManager deviceManager, DbContext dbContext)
     {


### PR DESCRIPTION
Changed the types of `_connectionString`, `_emailAddress`, and `_responseMessage` in `SettingsViewModel.cs` from `string` to `string?` to allow these properties to hold `null` values, representing the absence of a value.