### PR TITLE
Improve UI updates and error handling in device views

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -43,11 +43,6 @@ public partial class DeviceDetailViewModel : ObservableObject
     [ObservableProperty]
     private string _emailAddress;
 
-    [ObservableProperty]
-    private string _responseMessage;
-
-    [ObservableProperty]
-    private string _responseMessageColor = "Red";
 
     private System.Timers.Timer _updateTimer;
 
@@ -62,21 +57,20 @@ public partial class DeviceDetailViewModel : ObservableObject
         _mainViewModel = mainViewModel;
         _dbContext = dbContext;
 
-        ResponseMessage = string.Empty;
-
         LoadUserSettings().ConfigureAwait(false);
+        LoadDeviceDetailsAsync(DeviceId).ConfigureAwait(false);
 
         //FIXA VID BORTTAGNING OM EN ENHET INTE LÄNGRE EXISTERAR, BUG
-        _updateTimer = new System.Timers.Timer(5000);
-        _updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId);
-        _updateTimer.Start();
+        //_updateTimer = new System.Timers.Timer(5000);
+        //_updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId);
+        //_updateTimer.Start();
     }
 
-    ~DeviceDetailViewModel()
-    {
-        _updateTimer?.Stop();
-        _updateTimer?.Dispose();
-    }
+    //~DeviceDetailViewModel()
+    //{
+    //    _updateTimer?.Stop();
+    //    _updateTimer?.Dispose();
+    //}
 
     private async Task LoadUserSettings()
     {
@@ -101,7 +95,10 @@ public partial class DeviceDetailViewModel : ObservableObject
         {
             if (ConnectionState.ToLower() != "true")
             {
-                ResponseMessage = "Failed to toggle device state. Make sure the device is connected and running.";
+                await Application.Current!.MainPage!.DisplayAlert(
+                "Error",
+                "Failed to toggle device state. Make sure the device connectionstring and deviceid is added to WPF-IOT application and the app is running.",
+                "Ok");
                 return;
             }
 
@@ -110,8 +107,11 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             if (!response.Succeeded || response.Content is not CloudToDeviceMethodResult result || result.Status != 200)
             {
-                ResponseMessage = "Failed to toggle device state. Make sure the device is connected and running.";
                 Debug.WriteLine($"Error in ToggleStateAsync: {response.Message}");
+                await Application.Current!.MainPage!.DisplayAlert(
+                "Error",
+                "Failed to toggle device state. Make sure the device connectionstring and deviceid is added to WPF-IOT application and the app is running.",
+                "Ok");
                 return;
             }
 
@@ -119,7 +119,6 @@ public partial class DeviceDetailViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            ResponseMessage = "Unable to toggle the device state. Please check if the device is online and try again.";
             Debug.WriteLine($"Error in ToggleStateAsync: {ex.Message}");
         }
     }
@@ -137,13 +136,16 @@ public partial class DeviceDetailViewModel : ObservableObject
             }
             else
             {
-                ResponseMessage = "Failed to connect the device. Make sure the device is reachable.";
                 Debug.WriteLine($"Error in ConnectAsync: {response.Message}");
+                await Application.Current!.MainPage!.DisplayAlert(
+                "Error",
+                "Failed to connect the device. Make sure the device is reachable.",
+                "Ok");
+                return;
             }
         }
         catch (Exception ex)
         {
-            ResponseMessage = "Unable to connect to the device. Please check if the device is online and try again.";
             Debug.WriteLine($"Error in ConnectAsync: {ex.Message}");
         }
     }
@@ -161,13 +163,16 @@ public partial class DeviceDetailViewModel : ObservableObject
             }
             else
             {
-                ResponseMessage = "Failed to disconnect the device. Make sure the device is reachable.";
                 Debug.WriteLine($"Error in DisconnectAsync: {response.Message}");
+                await Application.Current!.MainPage!.DisplayAlert(
+                "Error",
+                "Failed to disconnect the device. Make sure the device is reachable.",
+                "Ok");
+                return;
             }
         }
         catch (Exception ex)
         {
-            ResponseMessage = "Unable to disconnect the device. Please check if the device is online and try again.";
             Debug.WriteLine($"Error in DisconnectAsync: {ex.Message}");
         }
     }
@@ -186,45 +191,54 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             if (response.Succeeded && response.Content is Twin twin)
             {
-                ConnectionState = twin.Properties.Reported.Contains("connectionState")
-                    ? twin.Properties.Reported["connectionState"].ToString()
-                    : (twin.Properties.Desired.Contains("connectionState")
-                        ? twin.Properties.Desired["connectionState"].ToString()
-                        : "Unknown");
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    ConnectionState = twin.Properties.Reported.Contains("connectionState")
+                        ? twin.Properties.Reported["connectionState"].ToString()
+                        : (twin.Properties.Desired.Contains("connectionState")
+                            ? twin.Properties.Desired["connectionState"].ToString()
+                            : "Unknown");
 
-                DeviceName = twin.Properties.Reported.Contains("deviceName")
-                    ? twin.Properties.Reported["deviceName"].ToString()
-                    : (twin.Properties.Desired.Contains("deviceName")
-                        ? twin.Properties.Desired["deviceName"].ToString()
-                        : "Unknown");
+                    DeviceName = twin.Properties.Reported.Contains("deviceName")
+                        ? twin.Properties.Reported["deviceName"].ToString()
+                        : (twin.Properties.Desired.Contains("deviceName")
+                            ? twin.Properties.Desired["deviceName"].ToString()
+                            : "Unknown");
 
-                DeviceType = twin.Properties.Reported.Contains("deviceType")
-                    ? twin.Properties.Reported["deviceType"].ToString()
-                    : (twin.Properties.Desired.Contains("deviceType")
-                        ? twin.Properties.Desired["deviceType"].ToString()
-                        : "Unknown");
+                    DeviceType = twin.Properties.Reported.Contains("deviceType")
+                        ? twin.Properties.Reported["deviceType"].ToString()
+                        : (twin.Properties.Desired.Contains("deviceType")
+                            ? twin.Properties.Desired["deviceType"].ToString()
+                            : "Unknown");
 
-                DeviceState = twin.Properties.Reported.Contains("deviceState")
-                    ? (bool)twin.Properties.Reported["deviceState"] ? "On" : "Off"
-                    : (twin.Properties.Desired.Contains("deviceState")
-                        ? (bool)twin.Properties.Desired["deviceState"] ? "On" : "Off"
-                        : "Unknown");
+                    DeviceState = twin.Properties.Reported.Contains("deviceState")
+                        ? (bool)twin.Properties.Reported["deviceState"] ? "On" : "Off"
+                        : (twin.Properties.Desired.Contains("deviceState")
+                            ? (bool)twin.Properties.Desired["deviceState"] ? "On" : "Off"
+                            : "Unknown");
 
-                LastActivityTime = twin.LastActivityTime.HasValue
-                    ? twin.LastActivityTime.Value.ToString("yyyy-MM-dd HH:mm:ss")
-                    : "No Activity";
-
+                    LastActivityTime = twin.LastActivityTime.HasValue
+                        ? twin.LastActivityTime.Value.ToString("yyyy-MM-dd HH:mm:ss")
+                        : "No Activity";
+                });
                 await SaveDeviceSettingsToDatabase(twin);
             }
             else
             {
-                ResponseMessage = "Failed to load device details.";
+                _updateTimer?.Stop();
                 Debug.WriteLine($"Error in LoadDeviceDetailsAsync: {response.Message}");
+
+                await MainThread.InvokeOnMainThreadAsync(async () =>
+                {
+                    await Application.Current!.MainPage!.DisplayAlert(
+                        "Error",
+                        "Failed to load device details",
+                        "Ok");
+                });
             }
         }
         catch (Exception ex)
         {
-            ResponseMessage = $"Unable to load the device details. Please check if the device is online and try again.";
             Debug.WriteLine($"Error in LoadDeviceDetailsAsync: {ex.Message}");
         }
     }
@@ -257,22 +271,28 @@ public partial class DeviceDetailViewModel : ObservableObject
     [RelayCommand]
     private async Task RemoveDeviceAsync()
     {
+        _updateTimer?.Stop();
         try
         {
             if (string.IsNullOrWhiteSpace(EmailAddress))
             {
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Error",
-                "No email address registered. Cannot remove device.",
-                "Ok");
-                return;
+                await MainThread.InvokeOnMainThreadAsync(async () =>
+                {
+                    await Application.Current!.MainPage!.DisplayAlert(
+                    "Error",
+                    "No email address registered. Cannot remove device.",
+                    "Ok");
+                });
             }
 
-            var confirmed = await Application.Current!.MainPage!.DisplayAlert(
+            var confirmed = await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                return await Application.Current!.MainPage!.DisplayAlert(
                 "Confirm",
                 "Are you sure you want to remove this device?",
                 "Yes",
                 "No");
+            });
 
             if (!confirmed)
             {
@@ -283,26 +303,29 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             var response = await _deviceManager.DeviceRemovalSendEmailAsync(DeviceId, EmailAddress);
 
-            await Application.Current!.MainPage!.DisplayAlert(
-            "Success",
-            $"Device {DeviceId} removed successfully and email confirmation has been sent.",
-            "Ok");
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                await Application.Current!.MainPage!.DisplayAlert(
+                "Success",
+                $"Device {DeviceId} removed successfully and email confirmation has been sent.",
+                "Ok");
+            });
 
             await _mainViewModel.LoadDevicesAsync();
 
             _isRemovingDevice = false;
-
-            await Shell.Current.GoToAsync("///MainPage");
-
         }
         catch (Exception ex)
         {
             _isRemovingDevice = false;
-            await Application.Current!.MainPage!.DisplayAlert(
-            "Error",
-            "Unable to remove the device. Please check the device status and try again.",
-            "Ok");
             Debug.WriteLine($"Error in RemoveDeviceAsync: {ex.Message}");
+        }
+        finally
+        {
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                await Shell.Current.GoToAsync("///MainPage");
+            });
         }
     }
 }

--- a/SmartHomeMauiApp/MVVM/Views/DeviceDetailPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/DeviceDetailPage.xaml
@@ -97,14 +97,6 @@
                             Margin="10, 20, 10, 0"
                             IsVisible="{Binding IsRemoveDeviceVisible}" />
 
-                    <Label Text="{Binding ResponseMessage}"
-                           FontSize="Medium"
-                           TextColor="{Binding ResponseMessageColor}"
-                           HorizontalOptions="Center"
-                           VerticalOptions="Center"
-                           Margin="0,20,0,0"
-                           IsVisible="{Binding ResponseMessage, Converter={StaticResource StringToVisibilityConverter}}" />
-
                 </StackLayout>
             </Grid>
         </ScrollView>

--- a/SmartHomeMauiApp/MVVM/Views/MainPage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/MainPage.xaml.cs
@@ -9,4 +9,11 @@ public partial class MainPage : ContentPage
         InitializeComponent();
         BindingContext = viewModel;
     }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await (BindingContext as MainViewModel)!.LoadDevicesAsync();
+    }
+
 }


### PR DESCRIPTION
- Removed `_responseMessage` and `_responseMessageColor` from `DeviceDetailViewModel`.
- Replaced `ResponseMessage` with `DisplayAlert` for error messages.
- Commented out `_updateTimer` initialization and disposal.
- Updated `LoadDeviceDetailsAsync` to use `MainThread.InvokeOnMainThreadAsync`.
- Removed `ResponseMessage` label from `DeviceDetailPage.xaml`.
- Added `OnAppearing` method to `MainPage.xaml.cs` to load devices on page appearance.
- Modified `RemoveDeviceAsync` to use `MainThread.InvokeOnMainThreadAsync`.
- Ensured all UI updates are on the main thread using `MainThread.InvokeOnMainThreadAsync`.