### PR TITLE
Add OnAppearing override to reset view model state

### DIFF
--- a/SmartHomeMauiApp/MVVM/Views/AddDevicePage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/AddDevicePage.xaml.cs
@@ -9,4 +9,16 @@ public partial class AddDevicePage : ContentPage
         InitializeComponent();
         BindingContext = viewModel;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (BindingContext is AddDeviceViewModel viewModel)
+        {
+            viewModel.ResponseMessage = string.Empty;
+            viewModel.ResponseMessageColor = "Red";
+        }
+    }
+
 }


### PR DESCRIPTION
Introduced an override for the `OnAppearing` method in the `AddDevicePage` class. This method checks if the `BindingContext` is an `AddDeviceViewModel`. If so, it resets the `ResponseMessage` to an empty string and sets the `ResponseMessageColor` to "Red". This ensures the view model state is reset each time the page appears.