### PR TITLE
Update ViewModel properties and methods to nullable types

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
@@ -1,10 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Newtonsoft.Json;
 using Shared.Library.Models.IotResources;
 using Shared.Library.Services;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Net.Http.Json;
 
 namespace SmartHomeMauiApp.MVVM.ViewModels;
@@ -27,13 +25,13 @@ public partial class AddDeviceViewModel : ObservableObject
     private ObservableCollection<string> _availableDeviceTypes;
 
     [ObservableProperty]
-    private string _selectedDeviceType;
+    private string? _selectedDeviceType;
 
     [ObservableProperty]
-    private string _deviceId;
+    private string? _deviceId;
 
     [ObservableProperty]
-    private string _deviceName;
+    private string? _deviceName;
 
     [ObservableProperty]
     private string _responseMessage;

--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -60,7 +60,7 @@ public partial class DeviceDetailViewModel : ObservableObject
 
         //FIXA VID BORTTAGNING OM EN ENHET INTE LÄNGRE EXISTERAR, BUG
         _updateTimer = new System.Timers.Timer(5000);
-        _updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId);
+        _updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId!);
         _updateTimer.Start();
     }
 
@@ -76,7 +76,7 @@ public partial class DeviceDetailViewModel : ObservableObject
         EmailAddress = userSettings?.EmailAddress ?? string.Empty;
     }
 
-    partial void OnDeviceIdChanged(string value)
+    partial void OnDeviceIdChanged(string? value)
     {
         if (!string.IsNullOrEmpty(value))
         {

--- a/SmartHomeMauiApp/MVVM/ViewModels/HistoryViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/HistoryViewModel.cs
@@ -21,7 +21,7 @@ public partial class HistoryViewModel : ObservableObject
     private ObservableCollection<UserSettings> _userSettings = new();
 
     [ObservableProperty]
-    private string _responseMessage;
+    private string? _responseMessage;
 
     public HistoryViewModel(DbContext dbContext)
     {


### PR DESCRIPTION
Updated `AddDeviceViewModel` properties `_selectedDeviceType`, `_deviceId`, and `_deviceName` to nullable `string?`. Modified `DeviceDetailViewModel` to use non-nullable `DeviceId` with `!` in `_updateTimer.Elapsed` event handler and changed `OnDeviceIdChanged` to accept nullable `string?`. Changed `HistoryViewModel` `_responseMessage` property to nullable `string?`. These changes enhance null value handling and robustness.