### PR TITLE
Refactor MainViewModel timer initialization

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
@@ -38,7 +38,7 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private string? _conditionText;
 
-    private readonly System.Timers.Timer _timer;
+    private readonly System.Timers.Timer? _timer;
 
     public MainViewModel(IDeviceManager deviceManager, IDbContext dbContext)
     {
@@ -49,11 +49,16 @@ public partial class MainViewModel : ObservableObject
 
         LoadDevicesAsync().ConfigureAwait(false);
         LoadWeatherDataAsync().ConfigureAwait(false);
-        Time = DateTime.Now.ToString("HH:mm");
 
-        _timer = new System.Timers.Timer(10000);
-        _timer.Elapsed += UpdateTime!;
-        _timer.Start();
+        Time = DateTime.Now.ToString("HH:mm");
+        StartTimer();
+    }
+
+    private void StartTimer()
+    {
+        var timer = new System.Timers.Timer(10000);
+        timer.Elapsed += (sender, e) => Time = DateTime.Now.ToString("HH:mm");
+        timer.Start();
     }
 
     public void UpdateTime(object sender, ElapsedEventArgs e)


### PR DESCRIPTION
Changed _timer to nullable and moved its setup to StartTimer method. StartTimer initializes and configures the timer, setting its interval to 10 seconds and assigning an anonymous method to update the Time property. Called StartTimer at the end of the constructor. Updated Time property initialization to current time in "HH:mm" format. Removed direct assignment of UpdateTime to _timer.Elapsed event.