### PR TITLE
Add SmartHomeMauiApp.Tests project to solution

### DIFF
--- a/SmartHome.sln
+++ b/SmartHome.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateApp", "TemplateApp\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureFunctions", "AzureFunctions\AzureFunctions.csproj", "{B21155F5-DDE2-48B3-A61D-4B2528630DA3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartHomeMauiApp.Tests", "SmartHomeMauiApp.Tests\SmartHomeMauiApp.Tests.csproj", "{0C078F28-D66E-42FE-A582-BAE7292A113B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{B21155F5-DDE2-48B3-A61D-4B2528630DA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B21155F5-DDE2-48B3-A61D-4B2528630DA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B21155F5-DDE2-48B3-A61D-4B2528630DA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C078F28-D66E-42FE-A582-BAE7292A113B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C078F28-D66E-42FE-A582-BAE7292A113B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C078F28-D66E-42FE-A582-BAE7292A113B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C078F28-D66E-42FE-A582-BAE7292A113B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SmartHomeMauiApp.Tests/SmartHomeMauiApp.Tests.csproj
+++ b/SmartHomeMauiApp.Tests/SmartHomeMauiApp.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Shared.Library\Shared.Library.csproj" />
+		<ProjectReference Include="..\SmartHomeMauiApp\SmartHomeMauiApp.csproj" />
+	</ItemGroup>
+
+</Project>


### PR DESCRIPTION
A new test project named `SmartHomeMauiApp.Tests` has been added to the `SmartHome.sln` solution file. The solution configuration has been updated to include build and deploy configurations for the new test project for both Debug and Release configurations.

The `SmartHomeMauiApp.Tests.csproj` targets .NET 8.0 and Windows 10.0.19041.0, enables implicit usings and nullable reference types, and is marked as a test project that is not packable.

The new test project includes package references for `coverlet.collector` (version 6.0.0), `Microsoft.NET.Test.Sdk` (version 17.8.0), `xunit` (version 2.5.3), and `xunit.runner.visualstudio` (version 2.5.3). It also includes project references to `Shared.Library` and `SmartHomeMauiApp`.