### PR TITLE
Refactor navigation and alerts to use INavigationService

### DIFF
--- a/SmartHomeMauiApp.Tests/MVVM/ViewModels/MainViewModelTests.cs
+++ b/SmartHomeMauiApp.Tests/MVVM/ViewModels/MainViewModelTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.Azure.Devices.Shared;
 using Moq;
 using Shared.Library.Models;
+using Shared.Library.Models.WeatherApi;
 using Shared.Library.Services;
 using SmartHomeMauiApp.Database;
 using SmartHomeMauiApp.MVVM.ViewModels;
+using SmartHomeMauiApp.Services;
 using Xunit;
 
 namespace SmartHomeMauiApp.Tests.MVVM.ViewModels;
@@ -12,23 +14,29 @@ public class MainViewModelTests
 {
     private readonly Mock<IDeviceManager> _deviceManagerMock;
     private readonly Mock<IDbContext> _dbContextMock;
-    private readonly Mock<HttpClient> _httpClientMock;
+    private readonly Mock<IWeatherService> _weatherServiceMock;
+    private readonly Mock<INavigationService> _navigationServiceMock;
     private readonly MainViewModel _mainViewModel;
 
     public MainViewModelTests()
     {
         _deviceManagerMock = new Mock<IDeviceManager>();
         _dbContextMock = new Mock<IDbContext>();
-        _httpClientMock = new Mock<HttpClient>();
+        _weatherServiceMock = new Mock<IWeatherService>();
+        _navigationServiceMock = new Mock<INavigationService>();
 
-        // Initialize the MainViewModel with mocked dependencies
-        _mainViewModel = new MainViewModel(_deviceManagerMock.Object, _dbContextMock.Object, _httpClientMock.Object);
+        _mainViewModel = new MainViewModel(
+            _deviceManagerMock.Object,
+            _dbContextMock.Object,
+            _weatherServiceMock.Object,
+            _navigationServiceMock.Object
+        );
     }
 
     [Fact]
     public async Task LoadDevicesAsync_ShouldPopulateDevices_WhenResponseIsSuccessful()
     {
-        // Arrange: Prepare the mock response
+        // Arrange:
         var devices = new List<Twin>
         {
             new Twin("device1"),
@@ -45,65 +53,104 @@ public class MainViewModelTests
             .Setup(dm => dm.GetDevicesAsync(It.IsAny<string>()))
             .ReturnsAsync(responseResult);
 
-        // Act: Call the method being tested
+        // Act:
         await _mainViewModel.LoadDevicesAsync();
 
-        // Assert: Verify that the Devices collection was populated
+        // Assert:
         Assert.NotEmpty(_mainViewModel.Devices);
         Assert.Equal(2, _mainViewModel.Devices.Count);
     }
 
-    //[Fact]
-    //public async Task LoadDevicesAsync_ShouldSetResponseMessage_WhenResponseFails()
-    //{
-    //    // Arrange: Set up a failure response from the device manager
-    //    var responseResult = new ResponseResult
-    //    {
-    //        Succeeded = false,
-    //        Message = "Failed to retrieve devices"
-    //    };
+    [Fact]
+    public async Task LoadDevicesAsync_ShouldSetResponseMessage_WhenResponseFails()
+    {
+        // Arrange:
+        var responseResult = new ResponseResult
+        {
+            Succeeded = false,
+            Message = "Failed to retrieve devices"
+        };
 
-    //    _deviceManagerMock
-    //        .Setup(dm => dm.GetDevicesAsync(It.IsAny<string>()))
-    //        .ReturnsAsync(responseResult);
+        _deviceManagerMock
+            .Setup(dm => dm.GetDevicesAsync(It.IsAny<string>()))
+            .ReturnsAsync(responseResult);
 
-    //    // Act: Call the method being tested
-    //    await _mainViewModel.LoadDevicesAsync();
+        // Act:
+        await _mainViewModel.LoadDevicesAsync();
 
-    //    // Assert: Check if the response message is set correctly
-    //    Assert.Equal("Failed to retrieve devices.", _mainViewModel.ResponseMessage);
-    //}
+        // Assert:
+        Assert.Equal("Failed to retrieve devices.", _mainViewModel.ResponseMessage);
+    }
 
-    //[Fact]
-    //public async Task LoadWeatherDataAsync_ShouldSetWeatherProperties_WhenResponseIsSuccessful()
-    //{
-    //    // Arrange: Prepare a mock HTTP response for weather data
-    //    var weatherDataJson = @"
-    //    {
-    //        'current': {
-    //            'condition': {
-    //                'text': 'Sunny',
-    //                'icon': '//cdn.weatherapi.com/weather/64x64/day/113.png'
-    //            },
-    //            'temp_c': 25.0
-    //        }
-    //    }";
+    [Fact]
+    public async Task LoadWeatherDataAsync_ShouldSetWeatherProperties_WhenResponseIsSuccessful()
+    {
+        // Arrange:
+        var weatherData = new WeatherResponse
+        {
+            Current = new CurrentWeather
+            {
+                TempC = 25.0f,
+                Condition = new Shared.Library.Models.WeatherApi.Condition
+                {
+                    Text = "Sunny",
+                    Icon = "//cdn.weatherapi.com/weather/64x64/day/113.png"
+                }
+            }
+        };
 
-    //    var handler = new Mock<HttpMessageHandler>();
-    //    handler.SetupAnyRequest()
-    //        .ReturnsResponse(weatherDataJson, "application/json");
+        _weatherServiceMock
+            .Setup(ws => ws.GetWeatherAsync(It.IsAny<string>()))
+            .ReturnsAsync(weatherData);
 
-    //    var client = new HttpClient(handler.Object);
+        // Act:
+        await _mainViewModel.LoadWeatherDataAsync();
 
-    //    // Replace HttpClient with the mock client in your service if needed
-    //    // For example, inject the mock HttpClient into your MainViewModel
+        // Assert:
+        Assert.Equal("Sunny", _mainViewModel.ConditionText);
+        Assert.Equal("25°C", _mainViewModel.Temperature);
+        Assert.Equal("https://cdn.weatherapi.com/weather/64x64/day/113.png", _mainViewModel.WeatherIcon);
+    }
 
-    //    // Act: Call the method being tested
-    //    await _mainViewModel.LoadWeatherDataAsync();
+    [Fact]
+    public async Task LoadWeatherDataAsync_ShouldSetResponseMessage_WhenWeatherDataIsNull()
+    {
+        // Arrange:
+        _weatherServiceMock
+            .Setup(ws => ws.GetWeatherAsync(It.IsAny<string>()))
+            .ReturnsAsync((WeatherResponse?)null);
 
-    //    // Assert: Verify that the weather properties are set
-    //    Assert.Equal("Sunny", _mainViewModel.ConditionText);
-    //    Assert.Equal("25°C", _mainViewModel.Temperature);
-    //    Assert.Equal("https://cdn.weatherapi.com/weather/64x64/day/113.png", _mainViewModel.WeatherIcon);
-    //}
+        // Act:
+        await _mainViewModel.LoadWeatherDataAsync();
+
+        // Assert: 
+        Assert.Equal("Unable to display weather", _mainViewModel.ResponseMessage);
+    }
+
+    [Fact]
+    public async Task NavigateToDeviceDetailAsync_ShouldNavigateToDetailPage_WhenDeviceIsNotNull()
+    {
+        // Arrange
+        var twin = new Twin("device1");
+
+        var userSettings = new UserSettings { EmailAddress = "test@example.com" };
+        _dbContextMock.Setup(db => db.GetUserSettingsAsync())
+                      .ReturnsAsync(userSettings);
+
+        // Act
+        await _mainViewModel.NavigateToDeviceDetailAsync(twin);
+
+        // Assert:
+        _navigationServiceMock.Verify(nav => nav.NavigateToAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task NavigateToDeviceDetailAsync_ShouldNotNavigate_WhenDeviceIsNull()
+    {
+        // Act
+        await _mainViewModel.NavigateToDeviceDetailAsync(null);
+
+        // Assert:
+        _navigationServiceMock.Verify(nav => nav.NavigateToAsync(It.IsAny<string>()), Times.Never);
+    }
 }

--- a/SmartHomeMauiApp.Tests/SmartHomeMauiApp.Tests.csproj
+++ b/SmartHomeMauiApp.Tests/SmartHomeMauiApp.Tests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<UseMaui>true</UseMaui>
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 

--- a/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/AddDeviceViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.Input;
 using Shared.Library.Models.IotResources;
 using Shared.Library.Services;
+using SmartHomeMauiApp.Services;
 using System.Collections.ObjectModel;
 using System.Net.Http.Json;
 
@@ -11,11 +12,13 @@ public partial class AddDeviceViewModel : ObservableObject
 {
     private readonly IDeviceManager _deviceManager;
     private readonly MainViewModel _mainViewModel;
+    private readonly INavigationService _navigationService;
 
-    public AddDeviceViewModel(IDeviceManager deviceManager, MainViewModel viewModel)
+    public AddDeviceViewModel(IDeviceManager deviceManager, MainViewModel viewModel, INavigationService navigationService)
     {
         _deviceManager = deviceManager;
         _mainViewModel = viewModel;
+        _navigationService = navigationService;
 
         AvailableDeviceTypes = new ObservableCollection<string> { "Fan", "Lamp", "Ac" };
         ResponseMessage = string.Empty;
@@ -80,7 +83,7 @@ public partial class AddDeviceViewModel : ObservableObject
 
                 await Task.Delay(2000);
 
-                await Shell.Current.GoToAsync("///MainPage");
+                await _navigationService.NavigateToAsync("///MainPage");
             }
             else
             {

--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -6,6 +6,7 @@ using Shared.Library.Models;
 using Shared.Library.Services;
 using SmartHomeMauiApp.Database;
 using SmartHomeMauiApp.MVVM.Views;
+using SmartHomeMauiApp.Services;
 using System.Diagnostics;
 
 namespace SmartHomeMauiApp.MVVM.ViewModels;
@@ -17,6 +18,7 @@ public partial class DeviceDetailViewModel : ObservableObject
     private readonly IDeviceManager _deviceManager;
     private readonly MainViewModel _mainViewModel;
     private readonly IDbContext _dbContext;
+    private readonly INavigationService _navigationService;
     private bool _isRemovingDevice;
 
     [ObservableProperty]
@@ -50,11 +52,12 @@ public partial class DeviceDetailViewModel : ObservableObject
         DeviceId != "ac-3cea3c99-c45a-4f44-a8ea-1fb70b9d2dca" &&
         DeviceId != "new-lamp-33c0d9c6-66f2-4aa6-bef5-c3d4417bc74c";
 
-    public DeviceDetailViewModel(IDeviceManager deviceManager, MainViewModel mainViewModel, IDbContext dbContext)
+    public DeviceDetailViewModel(IDeviceManager deviceManager, MainViewModel mainViewModel, IDbContext dbContext, INavigationService navigationService)
     {
         _deviceManager = deviceManager;
         _mainViewModel = mainViewModel;
         _dbContext = dbContext;
+        _navigationService = navigationService;
 
         LoadUserSettings().ConfigureAwait(false);
 
@@ -93,10 +96,7 @@ public partial class DeviceDetailViewModel : ObservableObject
         {
             if (!ConnectionState!.Equals("true", StringComparison.CurrentCultureIgnoreCase))
             {
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Error",
-                "Failed to toggle device state. Make sure the device connectionstring and deviceid is added to WPF-IOT application and the app is running.",
-                "Ok");
+                await _navigationService.ShowAlertAsync("Error", "Failed to toggle device state. Ensure the device connection is correct and the app is running.", "Ok");
                 return;
             }
 
@@ -106,10 +106,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             if (!response.Succeeded || response.Content is not CloudToDeviceMethodResult result || result.Status != 200)
             {
                 Debug.WriteLine($"Error in ToggleStateAsync: {response.Message}");
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Error",
-                "Failed to toggle device state. Make sure the device connectionstring and deviceid is added to WPF-IOT application and the app is running.",
-                "Ok");
+                await _navigationService.ShowAlertAsync("Error", "Failed to toggle device state.", "Ok");
                 return;
             }
 
@@ -135,11 +132,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             else
             {
                 Debug.WriteLine($"Error in ConnectAsync: {response.Message}");
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Error",
-                "Failed to connect the device. Make sure the device is reachable.",
-                "Ok");
-                return;
+                await _navigationService.ShowAlertAsync("Error", "Failed to connect the device. Ensure the device is reachable.", "Ok");
             }
         }
         catch (Exception ex)
@@ -162,11 +155,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             else
             {
                 Debug.WriteLine($"Error in DisconnectAsync: {response.Message}");
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Error",
-                "Failed to disconnect the device. Make sure the device is reachable.",
-                "Ok");
-                return;
+                await _navigationService.ShowAlertAsync("Error", "Failed to disconnect the device. Ensure the device is reachable.", "Ok");
             }
         }
         catch (Exception ex)
@@ -224,14 +213,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             else
             {
                 Debug.WriteLine($"Error in LoadDeviceDetailsAsync: {response.Message}");
-
-                await MainThread.InvokeOnMainThreadAsync(async () =>
-                {
-                    await Application.Current!.MainPage!.DisplayAlert(
-                        "Error",
-                        "Failed to load device details",
-                        "Ok");
-                });
+                await _navigationService.ShowAlertAsync("Error", "Failed to load device details.", "Ok");
             }
         }
         catch (Exception ex)
@@ -272,24 +254,11 @@ public partial class DeviceDetailViewModel : ObservableObject
         {
             if (string.IsNullOrWhiteSpace(EmailAddress))
             {
-                await MainThread.InvokeOnMainThreadAsync(async () =>
-                {
-                    await Application.Current!.MainPage!.DisplayAlert(
-                    "Error",
-                    "No email address registered. Cannot remove device.",
-                    "Ok");
-                });
+                await _navigationService.ShowAlertAsync("Error", "No email address registered. Cannot remove device.", "Ok");
                 return;
             }
 
-            var confirmed = await MainThread.InvokeOnMainThreadAsync(async () =>
-            {
-                return await Application.Current!.MainPage!.DisplayAlert(
-                "Confirm",
-                "Are you sure you want to remove this device?",
-                "Yes",
-                "No");
-            });
+            var confirmed = await _navigationService.ShowConfirmationAsync("Confirm", "Are you sure you want to remove this device?", "Yes", "No");
 
             if (!confirmed)
             {
@@ -303,13 +272,7 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             var response = await _deviceManager.DeviceRemovalSendEmailAsync(DeviceId!, EmailAddress!);
 
-            await MainThread.InvokeOnMainThreadAsync(async () =>
-            {
-                await Application.Current!.MainPage!.DisplayAlert(
-                "Success",
-                $"Device {DeviceId} removed successfully and email confirmation has been sent.",
-                "Ok");
-            });
+            await _navigationService.ShowAlertAsync("Success", $"Device {DeviceId} removed successfully and email confirmation has been sent.", "Ok");
 
             await _mainViewModel.LoadDevicesAsync();
 
@@ -325,10 +288,7 @@ public partial class DeviceDetailViewModel : ObservableObject
             _updateTimer?.Stop();
             _updateTimer?.Dispose();
 
-            await MainThread.InvokeOnMainThreadAsync(async () =>
-            {
-                await Shell.Current.GoToAsync("///MainPage");
-            });
+            await _navigationService.NavigateToAsync("///MainPage");
         }
     }
 }

--- a/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/MainViewModel.cs
@@ -1,11 +1,10 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Azure.Devices.Shared;
-using Newtonsoft.Json;
 using Shared.Library.Models;
-using Shared.Library.Models.WeatherApi;
 using Shared.Library.Services;
 using SmartHomeMauiApp.Database;
+using SmartHomeMauiApp.Services;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Timers;
@@ -14,6 +13,7 @@ namespace SmartHomeMauiApp.MVVM.ViewModels;
 
 public partial class MainViewModel : ObservableObject
 {
+    private readonly INavigationService _navigationService;
     private readonly IDeviceManager _deviceManager;
     private readonly IDbContext _dbContext;
     private readonly IWeatherService _weatherService;
@@ -39,13 +39,12 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private string? _conditionText;
 
-    private readonly System.Timers.Timer? _timer;
-
-    public MainViewModel(IDeviceManager deviceManager, IDbContext dbContext, IWeatherService weatherService)
+    public MainViewModel(IDeviceManager deviceManager, IDbContext dbContext, IWeatherService weatherService, INavigationService navigationService)
     {
         _deviceManager = deviceManager;
         _dbContext = dbContext;
         _weatherService = weatherService;
+        _navigationService = navigationService;
 
         ResponseMessage = string.Empty;
 
@@ -61,11 +60,6 @@ public partial class MainViewModel : ObservableObject
         var timer = new System.Timers.Timer(10000);
         timer.Elapsed += (sender, e) => Time = DateTime.Now.ToString("HH:mm");
         timer.Start();
-    }
-
-    public void UpdateTime(object sender, ElapsedEventArgs e)
-    {
-        Time = DateTime.Now.ToString("HH:mm");
     }
 
     public async Task LoadWeatherDataAsync()
@@ -142,10 +136,9 @@ public partial class MainViewModel : ObservableObject
         if (device == null)
             return;
 
-
         var userSettings = await _dbContext.GetUserSettingsAsync();
         var emailAddress = userSettings?.EmailAddress ?? string.Empty;
 
-        await Shell.Current.GoToAsync($"///DeviceDetailPage?deviceId={device.DeviceId}&emailAddress={emailAddress}");
+        await _navigationService.NavigateToAsync($"///DeviceDetailPage?deviceId={device.DeviceId}&emailAddress={emailAddress}");
     }
 }

--- a/SmartHomeMauiApp/MauiProgram.cs
+++ b/SmartHomeMauiApp/MauiProgram.cs
@@ -4,6 +4,7 @@ using SmartHomeMauiApp.Database;
 using SmartHomeMauiApp.MVVM.ViewModels;
 using SmartHomeMauiApp.MVVM.Views;
 using SmartHomeMauiApp.Resources.Converters;
+using SmartHomeMauiApp.Services;
 
 namespace SmartHomeMauiApp;
 
@@ -33,24 +34,10 @@ public static class MauiProgram
             return new DeviceManager(connectionString);
         });
 
-        builder.Services.AddSingleton<MainViewModel>();
-        builder.Services.AddSingleton<MainPage>();
-
-        builder.Services.AddSingleton<SettingsViewModel>();
-        builder.Services.AddSingleton<SettingsPage>();
-
-        builder.Services.AddSingleton<DeviceDetailViewModel>();
-        builder.Services.AddSingleton<DeviceDetailPage>();
-
-        builder.Services.AddSingleton<AddDeviceViewModel>();
-        builder.Services.AddSingleton<AddDevicePage>();
-
-        builder.Services.AddSingleton<HistoryViewModel>();
-        builder.Services.AddSingleton<HistoryPage>();
-
-        builder.Services.AddHttpClient<IWeatherService, WeatherService>();
-
-        builder.Services.AddTransient<DeviceTypeToImageConverter>();
+        if (!IsRunningUnitTests)
+        {
+            RegisterPlatformSpecificServices(builder.Services);
+        }
 
 #if DEBUG
         builder.Logging.AddDebug();
@@ -62,6 +49,32 @@ public static class MauiProgram
 
         return app;
     }
+
+    private static void RegisterPlatformSpecificServices(IServiceCollection services)
+    {
+        services.AddSingleton<MainViewModel>();
+        services.AddSingleton<MainPage>();
+
+        services.AddSingleton<SettingsViewModel>();
+        services.AddSingleton<SettingsPage>();
+
+        services.AddSingleton<DeviceDetailViewModel>();
+        services.AddSingleton<DeviceDetailPage>();
+
+        services.AddSingleton<AddDeviceViewModel>();
+        services.AddSingleton<AddDevicePage>();
+
+        services.AddSingleton<HistoryViewModel>();
+        services.AddSingleton<HistoryPage>();
+
+        services.AddSingleton<INavigationService, NavigationService>();
+        services.AddHttpClient<IWeatherService, WeatherService>();
+
+        services.AddTransient<DeviceTypeToImageConverter>();
+    }
+
+    private static bool IsRunningUnitTests =>
+        AppDomain.CurrentDomain.GetAssemblies().Any(a => a.FullName!.StartsWith("xunit"));
 
     private static async void SeedInitialData(IServiceProvider services)
     {

--- a/SmartHomeMauiApp/Services/INavigationService.cs
+++ b/SmartHomeMauiApp/Services/INavigationService.cs
@@ -1,0 +1,9 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public interface INavigationService
+{
+    Task NavigateToAsync(string route);
+    Task ShowAlertAsync(string title, string message, string cancel);
+    Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel);
+}
+

--- a/SmartHomeMauiApp/Services/NavigationService.cs
+++ b/SmartHomeMauiApp/Services/NavigationService.cs
@@ -1,0 +1,27 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public class NavigationService : INavigationService
+{
+    public Task NavigateToAsync(string route)
+    {
+        return Shell.Current.GoToAsync(route);
+    }
+
+    public async Task ShowAlertAsync(string title, string message, string cancel)
+    {
+        if (Application.Current?.MainPage != null)
+        {
+            await Application.Current.MainPage.DisplayAlert(title, message, cancel);
+        }
+    }
+
+    public async Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel)
+    {
+        if (Application.Current?.MainPage != null)
+        {
+            return await Application.Current.MainPage.DisplayAlert(title, message, accept, cancel);
+        }
+
+        return false;
+    }
+}

--- a/SmartHomeMauiApp/SmartHomeMauiApp.csproj
+++ b/SmartHomeMauiApp/SmartHomeMauiApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
@@ -13,7 +13,15 @@
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
-		<OutputType>Exe</OutputType>
+		<!-- Output type should be executable for platform-specific frameworks -->
+		<OutputType Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'">Exe</OutputType>
+		<OutputType Condition="'$(TargetFramework)' == 'net8.0-android'">Exe</OutputType>
+		<OutputType Condition="'$(TargetFramework)' == 'net8.0-ios'">Exe</OutputType>
+		<OutputType Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">Exe</OutputType>
+
+		<!-- Output type should be library for the test framework (net8.0) -->
+		<OutputType Condition="'$(TargetFramework)' == 'net8.0'">Library</OutputType>
+
 		<RootNamespace>SmartHomeMauiApp</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
@@ -70,7 +78,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Content Include="$smarthome$.targetsize-16.png" />
+		<Content Include="$smarthome$.targetsize-16.png" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Introduce INavigationService to handle navigation and alert display, replacing direct calls to Shell.Current.GoToAsync and Application.Current.MainPage.DisplayAlert. This change improves testability by allowing these actions to be mocked in unit tests.

- Updated MainViewModelTests.cs to use mocks for IWeatherService and INavigationService, and added new tests for LoadDevicesAsync, LoadWeatherDataAsync, and NavigateToDeviceDetailAsync.
- Modified SmartHomeMauiApp.Tests.csproj to change the target framework to net8.0 and enable MAUI.
- Updated AddDeviceViewModel.cs, DeviceDetailViewModel.cs, and MainViewModel.cs to use INavigationService.
- Updated MauiProgram.cs to register platform-specific services only when not running unit tests, and added RegisterPlatformSpecificServices method.
- Updated SmartHomeMauiApp.csproj to conditionally set OutputType based on the target framework and include net8.0 for unit tests.
- Added new INavigationService interface and NavigationService class to implement navigation and alert methods.