### PR TITLE
Add dynamic response message color to SettingsPage

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
@@ -21,6 +21,9 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private string? _responseMessage;
 
+    [ObservableProperty]
+    private string _responseMessageColor = "Red";
+
     public SettingsViewModel(IDeviceManager deviceManager, IDbContext dbContext)
     {
         _deviceManager = deviceManager;
@@ -59,11 +62,13 @@ public partial class SettingsViewModel : ObservableObject
             await _dbContext.SaveIoTHubSettingsAsync(iotHubSettings);
 
             ResponseMessage = "Settings have been saved, and IoT Hub connection has been updated.";
+            ResponseMessageColor = "Green";
             Preferences.Set("EmailAddress", EmailAddress);
         }
         catch (Exception ex)
         {
             ResponseMessage = "An error occurred while saving settings. Please try again.";
+            ResponseMessageColor = "Red";
             Debug.WriteLine($"Error in SaveSettingsAsync: {ex.Message}");
         }
 

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
@@ -60,7 +60,7 @@
 
                 <Label Text="{Binding ResponseMessage}"
                        FontSize="Medium"
-                       TextColor="Red"
+                       TextColor="{Binding ResponseMessageColor}"
                        HorizontalOptions="Center"
                        VerticalOptions="Center"
                        Margin="0,20,0,0"

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
@@ -4,9 +4,20 @@ namespace SmartHomeMauiApp.MVVM.Views;
 
 public partial class SettingsPage : ContentPage
 {
-	public SettingsPage(SettingsViewModel viewModel)
-	{
-		InitializeComponent();
-		BindingContext = viewModel;
-	}
+    public SettingsPage(SettingsViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (BindingContext is SettingsViewModel viewModel)
+        {
+            viewModel.ResponseMessage = string.Empty;
+            viewModel.ResponseMessageColor = "Red";
+        }
+    }
 }


### PR DESCRIPTION
Updated SettingsViewModel to include a new observable property `ResponseMessageColor` with a default value of "Red". Modified `SaveSettingsAsync` to set `ResponseMessageColor` to "Green" on success and "Red" on error. Updated `SettingsPage.xaml` to bind the `Label`'s `TextColor` to `ResponseMessageColor`. Refactored `SettingsPage` constructor for proper initialization and added `OnAppearing` method to reset response properties.