### PR TITLE
Add IPreferencesService and update SettingsViewModel

### DIFF
--- a/SmartHomeMauiApp.Tests/MVVM/ViewModels/SettingsViewModelTests.cs
+++ b/SmartHomeMauiApp.Tests/MVVM/ViewModels/SettingsViewModelTests.cs
@@ -1,0 +1,101 @@
+﻿using Moq;
+using Shared.Library.Models;
+using Shared.Library.Services;
+using SmartHomeMauiApp.Database;
+using SmartHomeMauiApp.MVVM.ViewModels;
+using SmartHomeMauiApp.Services;
+using Xunit;
+
+namespace SmartHomeMauiApp.Tests.MVVM.ViewModels;
+
+public class SettingsViewModelTests
+{
+    private readonly Mock<IDeviceManager> _deviceManagerMock;
+    private readonly Mock<IDbContext> _dbContextMock;
+    private readonly Mock<IPreferencesService> _preferencesServiceMock;
+    private readonly SettingsViewModel _settingsViewModel;
+
+    public SettingsViewModelTests()
+    {
+        _deviceManagerMock = new Mock<IDeviceManager>();
+        _dbContextMock = new Mock<IDbContext>();
+        _preferencesServiceMock = new Mock<IPreferencesService>();
+
+        _settingsViewModel = new SettingsViewModel(
+            _deviceManagerMock.Object,
+            _dbContextMock.Object,
+            _preferencesServiceMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task LoadSettingsAsync_ShouldPopulateSettings_WhenDataExists()
+    {
+        // Arrange
+        var userSettings = new UserSettings { EmailAddress = "test@example.com" };
+        var iotHubSettings = new IoTHubSettings { ConnectionString = "TestConnectionString" };
+
+        _dbContextMock.Setup(db => db.GetUserSettingsAsync())
+                      .ReturnsAsync(userSettings);
+        _dbContextMock.Setup(db => db.GetIoTHubSettingsAsync())
+                      .ReturnsAsync(iotHubSettings);
+
+        // Act
+        await _settingsViewModel.LoadSettingsAsync();
+
+        // Assert
+        Assert.Equal("test@example.com", _settingsViewModel.EmailAddress);
+        Assert.Equal("TestConnectionString", _settingsViewModel.ConnectionString);
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_ShouldSaveSettings_WhenConnectionStringIsValid()
+    {
+        // Arrange
+        _settingsViewModel.ConnectionString = "ValidConnectionString";
+        _settingsViewModel.EmailAddress = "test@example.com";
+
+        _dbContextMock.Setup(db => db.SaveUserSettingsAsync(It.IsAny<UserSettings>())).ReturnsAsync(1);
+        _dbContextMock.Setup(db => db.SaveIoTHubSettingsAsync(It.IsAny<IoTHubSettings>())).ReturnsAsync(1);
+
+        // Act
+        await _settingsViewModel.SaveSettingsAsync();
+
+        // Assert
+        _deviceManagerMock.Verify(dm => dm.UpdateConnectionString("ValidConnectionString"), Times.Once);
+        _dbContextMock.Verify(db => db.SaveUserSettingsAsync(It.IsAny<UserSettings>()), Times.Once);
+        _dbContextMock.Verify(db => db.SaveIoTHubSettingsAsync(It.IsAny<IoTHubSettings>()), Times.Once);
+
+        _preferencesServiceMock.Verify(ps => ps.Set("EmailAddress", "test@example.com"), Times.Once);
+    }
+
+
+    [Fact]
+    public async Task SaveSettingsAsync_ShouldShowError_WhenConnectionStringIsEmpty()
+    {
+        // Arrange
+        _settingsViewModel.ConnectionString = string.Empty;
+
+        // Act
+        await _settingsViewModel.SaveSettingsAsync();
+
+        // Assert
+        Assert.Equal("Connection String cannot be empty.", _settingsViewModel.ResponseMessage);
+        _deviceManagerMock.Verify(dm => dm.UpdateConnectionString(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_ShouldHandleException()
+    {
+        // Arrange
+        _settingsViewModel.ConnectionString = "ValidConnectionString";
+        _dbContextMock.Setup(db => db.SaveUserSettingsAsync(It.IsAny<UserSettings>())).ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        await _settingsViewModel.SaveSettingsAsync();
+
+        // Assert
+        Assert.Equal("An error occurred while saving settings. Please try again.", _settingsViewModel.ResponseMessage);
+        Assert.Equal("Red", _settingsViewModel.ResponseMessageColor);
+    }
+}

--- a/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Shared.Library.Models;
 using Shared.Library.Services;
 using SmartHomeMauiApp.Database;
+using SmartHomeMauiApp.Services;
 using System.Diagnostics;
 
 namespace SmartHomeMauiApp.MVVM.ViewModels;
@@ -11,6 +12,7 @@ public partial class SettingsViewModel : ObservableObject
 {
     private readonly IDeviceManager _deviceManager;
     private readonly IDbContext _dbContext;
+    private readonly IPreferencesService _preferencesService;
 
     [ObservableProperty]
     private string? _connectionString;
@@ -24,16 +26,20 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private string _responseMessageColor = "Red";
 
-    public SettingsViewModel(IDeviceManager deviceManager, IDbContext dbContext)
+    public SettingsViewModel(IDeviceManager deviceManager, IDbContext dbContext, IPreferencesService preferencesService)
     {
         _deviceManager = deviceManager;
         _dbContext = dbContext;
+        _preferencesService = preferencesService;
         ResponseMessage = string.Empty;
-
-        LoadSettings();
     }
 
-    public async void LoadSettings()
+    public async Task InitializeAsync()
+    {
+        await LoadSettingsAsync();
+    }
+
+    public async Task LoadSettingsAsync()
     {
         var userSettings = await _dbContext.GetUserSettingsAsync();
         EmailAddress = userSettings?.EmailAddress ?? string.Empty;
@@ -55,6 +61,8 @@ public partial class SettingsViewModel : ObservableObject
 
             _deviceManager.UpdateConnectionString(ConnectionString);
 
+            Debug.WriteLine("Saving settings...");
+
             var userSettings = new UserSettings { EmailAddress = EmailAddress };
             await _dbContext.SaveUserSettingsAsync(userSettings);
 
@@ -63,7 +71,7 @@ public partial class SettingsViewModel : ObservableObject
 
             ResponseMessage = "Settings have been saved, and IoT Hub connection has been updated.";
             ResponseMessageColor = "Green";
-            Preferences.Set("EmailAddress", EmailAddress);
+            _preferencesService.Set("EmailAddress", EmailAddress!);
         }
         catch (Exception ex)
         {

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
@@ -10,7 +10,7 @@ public partial class SettingsPage : ContentPage
         BindingContext = viewModel;
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
 
@@ -18,6 +18,7 @@ public partial class SettingsPage : ContentPage
         {
             viewModel.ResponseMessage = string.Empty;
             viewModel.ResponseMessageColor = "Red";
+            await viewModel.InitializeAsync();
         }
     }
 }

--- a/SmartHomeMauiApp/MauiProgram.cs
+++ b/SmartHomeMauiApp/MauiProgram.cs
@@ -52,6 +52,8 @@ public static class MauiProgram
         builder.Services.AddSingleton<HistoryPage>();
 
         builder.Services.AddSingleton<INavigationService, NavigationService>();
+        builder.Services.AddSingleton<IPreferencesService, PreferencesService>();
+
         builder.Services.AddHttpClient<IWeatherService, WeatherService>();
 
         builder.Services.AddTransient<DeviceTypeToImageConverter>();

--- a/SmartHomeMauiApp/Services/IPreferencesService.cs
+++ b/SmartHomeMauiApp/Services/IPreferencesService.cs
@@ -1,0 +1,7 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public interface IPreferencesService
+{
+    void Set(string key, string value);
+    string Get(string key, string defaultValue);
+}

--- a/SmartHomeMauiApp/Services/PreferencesService.cs
+++ b/SmartHomeMauiApp/Services/PreferencesService.cs
@@ -1,0 +1,14 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public class PreferencesService : IPreferencesService
+{
+    public void Set(string key, string value)
+    {
+        Preferences.Set(key, value);
+    }
+
+    public string Get(string key, string defaultValue)
+    {
+        return Preferences.Get(key, defaultValue);
+    }
+}


### PR DESCRIPTION
- Updated `SettingsViewModel` to include `IPreferencesService` dependency.
- Renamed `LoadSettings` to `LoadSettingsAsync` and made it asynchronous.
- Added `InitializeAsync` method to `SettingsViewModel`.
- Added debug logging to the settings save process.
- Updated `SettingsPage` to call `InitializeAsync` on page appearance.
- Registered `IPreferencesService` and `PreferencesService` in `MauiProgram`.
- Added `SettingsViewModelTests` with Moq for unit testing.
- Introduced `IPreferencesService` interface and `PreferencesService` implementation.