### PR TITLE
Refactor DeviceDetailViewModel for testability and cleanup

### DIFF
--- a/SmartHomeMauiApp.Tests/MVVM/ViewModels/DeviceDetailViewModelTests.cs
+++ b/SmartHomeMauiApp.Tests/MVVM/ViewModels/DeviceDetailViewModelTests.cs
@@ -1,0 +1,137 @@
+﻿using Microsoft.Azure.Devices;
+using Moq;
+using Shared.Library.Models;
+using Shared.Library.Services;
+using SmartHomeMauiApp.Database;
+using SmartHomeMauiApp.MVVM.ViewModels;
+using SmartHomeMauiApp.Services;
+using Xunit;
+
+namespace SmartHomeMauiApp.Tests.MVVM.ViewModels;
+
+public class DeviceDetailViewModelTests
+{
+    private readonly Mock<IDeviceManager> _deviceManagerMock;
+    private readonly Mock<INavigationService> _navigationServiceMock;
+    private readonly Mock<IDbContext> _dbContextMock;
+    private readonly Mock<ITimerService> _timerServiceMock;
+    private DeviceDetailViewModel _viewModel;
+
+    public DeviceDetailViewModelTests()
+    {
+        _deviceManagerMock = new Mock<IDeviceManager>();
+        _navigationServiceMock = new Mock<INavigationService>();
+        _dbContextMock = new Mock<IDbContext>();
+        _timerServiceMock = new Mock<ITimerService>();
+
+        _viewModel = new DeviceDetailViewModel(
+            _deviceManagerMock.Object,
+            _dbContextMock.Object,
+            _navigationServiceMock.Object,
+            _timerServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ShouldLoadUserSettingsAndStartTimer()
+    {
+        // Arrange
+        var userSettings = new UserSettings { EmailAddress = "test@example.com" };
+        _dbContextMock.Setup(db => db.GetUserSettingsAsync()).ReturnsAsync(userSettings);
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _dbContextMock.Verify(db => db.GetUserSettingsAsync(), Times.Once);
+        _timerServiceMock.Verify(ts => ts.Start(It.IsAny<Action>(), 5000), Times.Once);
+        Assert.Equal("test@example.com", _viewModel.EmailAddress);
+    }
+
+    [Fact]
+    public async Task ToggleStateAsync_ShouldShowError_WhenConnectionStateIsInvalid()
+    {
+        // Arrange
+        _viewModel.ConnectionState = "false";
+
+        // Act
+        await _viewModel.ToggleStateAsync();
+
+        // Assert
+        _navigationServiceMock.Verify(ns => ns.ShowAlertAsync("Error", "Failed to toggle device state. Ensure the device connection is correct and the app is running.", "Ok"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveDeviceAsync_ShouldShowError_WhenEmailAddressIsEmpty()
+    {
+        // Arrange
+        _viewModel.EmailAddress = string.Empty;
+
+        // Act
+        await _viewModel.RemoveDeviceAsync();
+
+        // Assert
+        _navigationServiceMock.Verify(ns => ns.ShowAlertAsync("Error", "No email address registered. Cannot remove device.", "Ok"), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemoveDeviceAsync_ShouldSendEmailAndRemoveDevice_WhenConfirmed()
+    {
+        // Arrange
+        _viewModel.EmailAddress = "test@example.com";
+        _navigationServiceMock.Setup(ns => ns.ShowConfirmationAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+        var response = new ResponseResult { Succeeded = true };
+        _deviceManagerMock.Setup(dm => dm.DeviceRemovalSendEmailAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
+
+        // Act
+        await _viewModel.RemoveDeviceAsync();
+
+        // Assert
+        _deviceManagerMock.Verify(dm => dm.DeviceRemovalSendEmailAsync(_viewModel.DeviceId!, _viewModel.EmailAddress), Times.Once);
+        _navigationServiceMock.Verify(ns => ns.NavigateToAsync("///MainPage"), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_ShouldStopTimer_WhenDisposed()
+    {
+        // Act
+        _viewModel.Dispose();
+
+        // Assert
+        _timerServiceMock.Verify(ts => ts.Stop(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToggleStateAsync_ShouldInvokeDirectMethod_WhenConnectionStateIsValid()
+    {
+        // Arrange
+        _viewModel.ConnectionState = "true";
+        _viewModel.DeviceState = "On";
+        var response = new ResponseResult { Succeeded = true, Content = new CloudToDeviceMethodResult { Status = 200 } };
+
+        _deviceManagerMock.Setup(dm => dm.InvokeDirectMethodAsync(It.IsAny<string>(), It.IsAny<string>(), null, 30))
+                          .ReturnsAsync(response);
+
+        // Act
+        await _viewModel.ToggleStateAsync();
+
+        // Assert
+        _deviceManagerMock.Verify(dm => dm.InvokeDirectMethodAsync(_viewModel.DeviceId!, "stop", null, 30), Times.Once);
+        _navigationServiceMock.Verify(ns => ns.ShowAlertAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConnectAsync_ShouldInvokeConnectDirectMethod_WhenCalled()
+    {
+        // Arrange
+        var response = new ResponseResult { Succeeded = true, Content = new CloudToDeviceMethodResult { Status = 200 } };
+
+        _deviceManagerMock.Setup(dm => dm.InvokeDirectMethodAsync(It.IsAny<string>(), "connect", null, 30))
+                          .ReturnsAsync(response);
+
+        // Act
+        await _viewModel.ConnectAsync();
+
+        // Assert
+        _deviceManagerMock.Verify(dm => dm.InvokeDirectMethodAsync(_viewModel.DeviceId!, "connect", null, 30), Times.Once);
+    }
+}

--- a/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/DeviceDetailViewModel.cs
@@ -5,7 +5,6 @@ using Microsoft.Azure.Devices.Shared;
 using Shared.Library.Models;
 using Shared.Library.Services;
 using SmartHomeMauiApp.Database;
-using SmartHomeMauiApp.MVVM.Views;
 using SmartHomeMauiApp.Services;
 using System.Diagnostics;
 
@@ -13,13 +12,14 @@ namespace SmartHomeMauiApp.MVVM.ViewModels;
 
 [QueryProperty(nameof(DeviceId), "deviceId")]
 [QueryProperty(nameof(EmailAddress), "emailAddress")]
-public partial class DeviceDetailViewModel : ObservableObject
+public partial class DeviceDetailViewModel : ObservableObject, IDisposable
 {
     private readonly IDeviceManager _deviceManager;
-    private readonly MainViewModel _mainViewModel;
     private readonly IDbContext _dbContext;
     private readonly INavigationService _navigationService;
+    private readonly ITimerService _timerService;
     private bool _isRemovingDevice;
+    private bool _disposed;
 
     [ObservableProperty]
     private string? _deviceId;
@@ -45,35 +45,30 @@ public partial class DeviceDetailViewModel : ObservableObject
     [ObservableProperty]
     private string? _emailAddress;
 
-    private System.Timers.Timer? _updateTimer;
-
     public bool IsRemoveDeviceVisible =>
         DeviceId != "new-fan-bd437070-7751-45ca-8040-d484cedd6201" &&
         DeviceId != "ac-3cea3c99-c45a-4f44-a8ea-1fb70b9d2dca" &&
         DeviceId != "new-lamp-33c0d9c6-66f2-4aa6-bef5-c3d4417bc74c";
 
-    public DeviceDetailViewModel(IDeviceManager deviceManager, MainViewModel mainViewModel, IDbContext dbContext, INavigationService navigationService)
+    public DeviceDetailViewModel(
+        IDeviceManager deviceManager,
+        IDbContext dbContext,
+        INavigationService navigationService,
+        ITimerService timerService)
     {
         _deviceManager = deviceManager;
-        _mainViewModel = mainViewModel;
         _dbContext = dbContext;
         _navigationService = navigationService;
-
-        LoadUserSettings().ConfigureAwait(false);
-
-        //FIXA VID BORTTAGNING OM EN ENHET INTE LÄNGRE EXISTERAR, BUG
-        _updateTimer = new System.Timers.Timer(5000);
-        _updateTimer.Elapsed += async (sender, e) => await LoadDeviceDetailsAsync(DeviceId!);
-        _updateTimer.Start();
+        _timerService = timerService;
     }
 
-    ~DeviceDetailViewModel()
+    public async Task InitializeAsync()
     {
-        _updateTimer?.Stop();
-        _updateTimer?.Dispose();
+        await LoadUserSettingsAsync();
+        _timerService.Start(() => LoadDeviceDetailsAsync(DeviceId!).ConfigureAwait(false), 5000);
     }
 
-    public async Task LoadUserSettings()
+    public async Task LoadUserSettingsAsync()
     {
         var userSettings = await _dbContext.GetUserSettingsAsync();
         EmailAddress = userSettings?.EmailAddress ?? string.Empty;
@@ -178,37 +173,35 @@ public partial class DeviceDetailViewModel : ObservableObject
 
             if (response.Succeeded && response.Content is Twin twin)
             {
-                await MainThread.InvokeOnMainThreadAsync(() =>
-                {
-                    ConnectionState = twin.Properties.Reported.Contains("connectionState")
-                        ? twin.Properties.Reported["connectionState"].ToString()
-                        : (twin.Properties.Desired.Contains("connectionState")
-                            ? twin.Properties.Desired["connectionState"].ToString()
-                            : "Unknown");
+                ConnectionState = twin.Properties.Reported.Contains("connectionState")
+                    ? twin.Properties.Reported["connectionState"].ToString()
+                    : (twin.Properties.Desired.Contains("connectionState")
+                        ? twin.Properties.Desired["connectionState"].ToString()
+                        : "Unknown");
 
-                    DeviceName = twin.Properties.Reported.Contains("deviceName")
-                        ? twin.Properties.Reported["deviceName"].ToString()
-                        : (twin.Properties.Desired.Contains("deviceName")
-                            ? twin.Properties.Desired["deviceName"].ToString()
-                            : "Unknown");
+                DeviceName = twin.Properties.Reported.Contains("deviceName")
+                    ? twin.Properties.Reported["deviceName"].ToString()
+                    : (twin.Properties.Desired.Contains("deviceName")
+                        ? twin.Properties.Desired["deviceName"].ToString()
+                        : "Unknown");
 
-                    DeviceType = twin.Properties.Reported.Contains("deviceType")
-                        ? twin.Properties.Reported["deviceType"].ToString()
-                        : (twin.Properties.Desired.Contains("deviceType")
-                            ? twin.Properties.Desired["deviceType"].ToString()
-                            : "Unknown");
+                DeviceType = twin.Properties.Reported.Contains("deviceType")
+                    ? twin.Properties.Reported["deviceType"].ToString()
+                    : (twin.Properties.Desired.Contains("deviceType")
+                        ? twin.Properties.Desired["deviceType"].ToString()
+                        : "Unknown");
 
-                    DeviceState = twin.Properties.Reported.Contains("deviceState")
-                        ? (bool)twin.Properties.Reported["deviceState"] ? "On" : "Off"
-                        : (twin.Properties.Desired.Contains("deviceState")
-                            ? (bool)twin.Properties.Desired["deviceState"] ? "On" : "Off"
-                            : "Unknown");
+                DeviceState = twin.Properties.Reported.Contains("deviceState")
+                    ? (bool)twin.Properties.Reported["deviceState"] ? "On" : "Off"
+                    : (twin.Properties.Desired.Contains("deviceState")
+                        ? (bool)twin.Properties.Desired["deviceState"] ? "On" : "Off"
+                        : "Unknown");
 
-                    LastActivityTime = twin.LastActivityTime.HasValue
-                        ? twin.LastActivityTime.Value.ToString("yyyy-MM-dd HH:mm:ss")
-                        : "No Activity";
-                });
-                await SaveDeviceSettingsToDatabase(twin);
+                LastActivityTime = twin.LastActivityTime.HasValue
+                    ? twin.LastActivityTime.Value.ToString("yyyy-MM-dd HH:mm:ss")
+                    : "No Activity";
+
+                await SaveDeviceSettingsToDatabaseAsync(twin);
             }
             else
             {
@@ -222,7 +215,7 @@ public partial class DeviceDetailViewModel : ObservableObject
         }
     }
 
-    public async Task SaveDeviceSettingsToDatabase(Twin twin)
+    public async Task SaveDeviceSettingsToDatabaseAsync(Twin twin)
     {
         var deviceSettings = await _dbContext.GetDeviceSettingsAsync(DeviceId!);
         if (deviceSettings == null)
@@ -265,16 +258,12 @@ public partial class DeviceDetailViewModel : ObservableObject
                 return;
             }
 
-            _updateTimer?.Stop();
-            _updateTimer?.Dispose();
-
+            _timerService.Stop();
             _isRemovingDevice = true;
 
             var response = await _deviceManager.DeviceRemovalSendEmailAsync(DeviceId!, EmailAddress!);
 
             await _navigationService.ShowAlertAsync("Success", $"Device {DeviceId} removed successfully and email confirmation has been sent.", "Ok");
-
-            await _mainViewModel.LoadDevicesAsync();
 
             _isRemovingDevice = false;
         }
@@ -285,10 +274,27 @@ public partial class DeviceDetailViewModel : ObservableObject
         }
         finally
         {
-            _updateTimer?.Stop();
-            _updateTimer?.Dispose();
-
+            _timerService.Stop();
             await _navigationService.NavigateToAsync("///MainPage");
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                _timerService.Stop();
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/SmartHomeMauiApp/MVVM/Views/DeviceDetailPage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/DeviceDetailPage.xaml.cs
@@ -4,9 +4,28 @@ namespace SmartHomeMauiApp.MVVM.Views;
 
 public partial class DeviceDetailPage : ContentPage
 {
-	public DeviceDetailPage(DeviceDetailViewModel viewModel)
-	{
-		InitializeComponent();
-		BindingContext = viewModel;
-	}
+    public DeviceDetailPage(DeviceDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+
+        if (BindingContext is DeviceDetailViewModel viewModel)
+        {
+            await viewModel.InitializeAsync();
+        }
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        if (BindingContext is DeviceDetailViewModel viewModel)
+        {
+            viewModel.Dispose();
+        }
+    }
 }

--- a/SmartHomeMauiApp/MauiProgram.cs
+++ b/SmartHomeMauiApp/MauiProgram.cs
@@ -53,6 +53,7 @@ public static class MauiProgram
 
         builder.Services.AddSingleton<INavigationService, NavigationService>();
         builder.Services.AddSingleton<IPreferencesService, PreferencesService>();
+        builder.Services.AddSingleton<ITimerService, TimerService>();
 
         builder.Services.AddHttpClient<IWeatherService, WeatherService>();
 

--- a/SmartHomeMauiApp/Services/ITimerService.cs
+++ b/SmartHomeMauiApp/Services/ITimerService.cs
@@ -1,0 +1,8 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public interface ITimerService
+{
+    void Start(Action callback, int interval);
+    void Stop();
+}
+

--- a/SmartHomeMauiApp/Services/TimerService.cs
+++ b/SmartHomeMauiApp/Services/TimerService.cs
@@ -1,0 +1,20 @@
+﻿namespace SmartHomeMauiApp.Services;
+
+public class TimerService : ITimerService
+{
+    private System.Timers.Timer? _timer;
+
+    public void Start(Action callback, int interval)
+    {
+        _timer = new System.Timers.Timer(interval);
+        _timer.Elapsed += (sender, args) => callback();
+        _timer.Start();
+    }
+
+    public void Stop()
+    {
+        _timer?.Stop();
+        _timer?.Dispose();
+    }
+}
+


### PR DESCRIPTION
- Added IDisposable to DeviceDetailViewModel for resource management.
- Introduced ITimerService to abstract timer functionality.
- Removed MainViewModel dependency.
- Refactored LoadUserSettings to LoadUserSettingsAsync.
- Updated LoadDeviceDetailsAsync to directly update properties.
- Added InitializeAsync method to start the timer using ITimerService.
- Implemented Dispose pattern to stop the timer on disposal.
- Modified DeviceDetailPage.xaml.cs constructor and lifecycle methods.
- Registered ITimerService in MauiProgram.cs.
- Added unit tests for DeviceDetailViewModel using Moq and Xunit.