### PR TITLE
Add TwinDeviceNameConverter and update MainPage display

### DIFF
--- a/SmartHomeMauiApp/App.xaml
+++ b/SmartHomeMauiApp/App.xaml
@@ -13,6 +13,7 @@
                     <converters:BooleanToColorConverter x:Key="BooleanToColorConverter" />
                     <converters:DeviceTypeToImageConverter x:Key="DeviceTypeToImageConverter" />
                     <converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
+                    <converters:TwinDeviceNameConverter x:Key="TwinDeviceNameConverter"/>
                     <Color x:Key="SemiTransparentGray">#E61E1E1E</Color>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>

--- a/SmartHomeMauiApp/MVVM/Views/MainPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/MainPage.xaml
@@ -94,20 +94,21 @@
                                                  VerticalOptions="Center">
                                         <Label Text="Device Id:"
                                                FontSize="16"
-                                               TextColor="Gray"
-                                               Margin="0,5,0,0" />
+                                               TextColor="Gray"/>
                                         <Label Text="{Binding DeviceId}"
                                                FontSize="18"
                                                TextColor="White"
                                                FontAttributes="Bold"
                                                LineBreakMode="TailTruncation" />
-                                        <Label Text="Last Activity:"
+                                        <Label Text="Device Name:"
                                                FontSize="16"
                                                TextColor="Gray"
                                                Margin="0,5,0,0" />
-                                        <Label Text="{Binding LastActivityTime, StringFormat='{}{0:MM/dd/yyyy hh:mm}'}"
-                                               FontSize="14"
-                                               TextColor="White" />
+                                        <Label Text="{Binding ., Converter={StaticResource TwinDeviceNameConverter}}"
+                                               FontSize="18"
+                                               TextColor="White"
+                                               FontAttributes="Bold"
+                                               LineBreakMode="TailTruncation" />
                                     </StackLayout>
 
                                     <Button Grid.Row="0"

--- a/SmartHomeMauiApp/Resources/Converters/TwinDeviceNameConverter.cs
+++ b/SmartHomeMauiApp/Resources/Converters/TwinDeviceNameConverter.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Azure.Devices.Shared;
+using System.Globalization;
+
+namespace SmartHomeMauiApp.Resources.Converters;
+
+public class TwinDeviceNameConverter : IValueConverter
+{
+    public object Convert(object? value, Type? targetType, object? parameter, CultureInfo culture)
+    {
+        var twin = value as Twin;
+        if (twin != null)
+        {
+            if (twin.Properties.Desired.Contains("deviceName"))
+            {
+                return twin.Properties.Desired["deviceName"].ToString();
+            }
+            else if (twin.Properties.Reported.Contains("deviceName"))
+            {
+                return twin.Properties.Reported["deviceName"].ToString();
+            }
+        }
+        return "Unknown Device";
+    }
+
+    public object ConvertBack(object? value, Type? targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Added TwinDeviceNameConverter to App.xaml resource dictionary. Modified MainPage.xaml to display device name instead of last activity. Created TwinDeviceNameConverter.cs to implement IValueConverter for extracting device names from twin properties.