### PR TITLE
Add null-forgiving operator in test method

### DIFF
--- a/SmartHomeMauiApp.Tests/MVVM/ViewModels/MainViewModelTests.cs
+++ b/SmartHomeMauiApp.Tests/MVVM/ViewModels/MainViewModelTests.cs
@@ -112,7 +112,7 @@ public class MainViewModelTests
     public async Task NavigateToDeviceDetailAsync_ShouldNotNavigate_WhenDeviceIsNull()
     {
         // Act
-        await _mainViewModel.NavigateToDeviceDetailAsync(null);
+        await _mainViewModel.NavigateToDeviceDetailAsync(null!);
 
         // Assert:
         _navigationServiceMock.Verify(nav => nav.NavigateToAsync(It.IsAny<string>()), Times.Never);


### PR DESCRIPTION
Updated the `NavigateToDeviceDetailAsync_ShouldNotNavigate_WhenDeviceIsNull` test method in `MainViewModelTests` to include a null-forgiving operator (`!`) in the call to `_mainViewModel.NavigateToDeviceDetailAsync`. This change prevents compiler warnings about passing a `null` value to a method that may not accept it.