### PR TITLE
Update database name and remove hardcoded email

### DIFF
--- a/SmartHomeMauiApp/Database/SmarthomeContext.cs
+++ b/SmartHomeMauiApp/Database/SmarthomeContext.cs
@@ -9,7 +9,7 @@ public class SmarthomeContext : ISmarthomeContext
 
     public SmarthomeContext()
     {
-        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "smarthometester.db3");
+        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "smarthome.db3");
         Console.WriteLine($"Db added to {dbPath}");
         _database = new SQLiteAsyncConnection(dbPath);
     }

--- a/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
@@ -42,7 +42,7 @@ public partial class SettingsViewModel : ObservableObject
     public async Task LoadSettingsAsync()
     {
         var userSettings = await _dbContext.GetUserSettingsAsync();
-        EmailAddress = userSettings?.EmailAddress ?? "mille.elfver98@gmail.com";
+        EmailAddress = userSettings?.EmailAddress ?? string.Empty;
 
         var iotHubSettings = await _dbContext.GetIoTHubSettingsAsync();
         ConnectionString = iotHubSettings?.ConnectionString ?? "HostName=Milles-IoT.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=4o/msHXU6XCzmeL9Jazb6eKlPZJbf6D4KAIoTFqR/EI=";


### PR DESCRIPTION
Changed the database file name in `SmarthomeContext` from `smarthometester.db3` to `smarthome.db3` to reflect a move to production. Updated `SettingsViewModel` to replace the hardcoded email address with an empty string for improved privacy.