### PR TITLE
Set WidthRequest for UI elements on Android and WinUI

### DIFF
--- a/SmartHomeMauiApp/MVVM/Views/AddDevicePage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/AddDevicePage.xaml
@@ -27,6 +27,7 @@
                 <Picker Title="Select Device Type"
                         Background="#333"
                         ItemsSource="{Binding AvailableDeviceTypes}"
+                        WidthRequest="{OnPlatform Android='300'}"
                         SelectedItem="{Binding SelectedDeviceType}"
                         HorizontalOptions="FillAndExpand"
                         Margin="{OnPlatform Android='0,10,0,0'}" />
@@ -38,6 +39,7 @@
                        PlaceholderColor="Gray"
                        FontSize="{OnPlatform Android='14', WinUI='14'}"
                        HeightRequest="{OnPlatform Android='40', WinUI='20'}"
+                       WidthRequest="{OnPlatform Android='300'}"
                        HorizontalOptions="FillAndExpand"
                        Margin="{OnPlatform Android='0,10,0,10', WinUI='0,0,0,0'}" />
 
@@ -63,6 +65,7 @@
                 <Button Text="Add Device"
                         Command="{Binding AddDeviceCommand}"
                         BackgroundColor="Green"
+                        WidthRequest="{OnPlatform Android='200'}"
                         TextColor="White"
                         HorizontalOptions="FillAndExpand"
                         Margin="{OnPlatform Android='0,20,0,0', WinUI='0,10,0,0'}" />

--- a/SmartHomeMauiApp/MVVM/Views/MainPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/MainPage.xaml
@@ -116,7 +116,7 @@
                                             BackgroundColor="#6f42c1"
                                             TextColor="White"
                                             CornerRadius="20"
-                                            WidthRequest="{OnPlatform Android='100', WinUI='80'}"
+                                            WidthRequest="{OnPlatform Android='60', WinUI='80'}"
                                             HeightRequest="{OnPlatform Android='40'}"
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:MainViewModel}}, Path=NavigateToDeviceDetailCommand}"
                                             CommandParameter="{Binding .}"

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
@@ -15,6 +15,7 @@
         <ScrollView>
             <StackLayout Padding="30"
                          Spacing="20"
+                         WidthRequest="{OnPlatform WinUI='1050'}"
                          VerticalOptions="CenterAndExpand"
                          HorizontalOptions="CenterAndExpand"
                          BackgroundColor="Transparent">


### PR DESCRIPTION
In `AddDevicePage.xaml`:
- Added `WidthRequest` property to the `Picker` element to set its width to 300 on Android.
- Added `WidthRequest` property to the `Entry` element to set its width to 300 on Android.
- Added `WidthRequest` property to the `Button` element to set its width to 200 on Android.

In `MainPage.xaml`:
- Changed the `WidthRequest` property of a `Button` element from 100 to 60 on Android.

In `SettingsPage.xaml`:
- Added `WidthRequest` property to the `StackLayout` element to set its width to 1050 on WinUI.

These changes ensure consistent sizing across different platforms, enhancing the uniform look and feel of the application.