### PR TITLE
Refactor Settings initialization and improve error message

### DIFF
--- a/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
+++ b/SmartHomeMauiApp/MVVM/ViewModels/SettingsViewModel.cs
@@ -34,11 +34,6 @@ public partial class SettingsViewModel : ObservableObject
         ResponseMessage = string.Empty;
     }
 
-    public async Task InitializeAsync()
-    {
-        await LoadSettingsAsync();
-    }
-
     public async Task LoadSettingsAsync()
     {
         var userSettings = await _dbContext.GetUserSettingsAsync();
@@ -75,7 +70,7 @@ public partial class SettingsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            ResponseMessage = "An error occurred while saving settings. Please try again.";
+            ResponseMessage = "An error occurred while saving settings. Please double check that your Iot-Hub connectionstring is valid.";
             ResponseMessageColor = "Red";
             Debug.WriteLine($"Error in SaveSettingsAsync: {ex.Message}");
         }

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml
@@ -64,6 +64,7 @@
                        TextColor="{Binding ResponseMessageColor}"
                        HorizontalOptions="Center"
                        VerticalOptions="Center"
+                       HorizontalTextAlignment="Center"
                        Margin="0,20,0,0"
                        IsVisible="{Binding ResponseMessage, Converter={StaticResource StringToVisibilityConverter}}" />
 

--- a/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
+++ b/SmartHomeMauiApp/MVVM/Views/SettingsPage.xaml.cs
@@ -18,7 +18,7 @@ public partial class SettingsPage : ContentPage
         {
             viewModel.ResponseMessage = string.Empty;
             viewModel.ResponseMessageColor = "Red";
-            await viewModel.InitializeAsync();
+            await viewModel.LoadSettingsAsync();
         }
     }
 }


### PR DESCRIPTION
Removed InitializeAsync from SettingsViewModel, replaced with direct call to LoadSettingsAsync. Updated SaveSettingsAsync error message for better guidance on Iot-Hub connection string. Centered text in SettingsPage.xaml Label. Updated OnAppearing in SettingsPage.xaml.cs to call LoadSettingsAsync.