### PR TITLE
Update assertion message in SettingsViewModelTests

### DIFF
--- a/SmartHomeMauiApp.Tests/MVVM/ViewModels/SettingsViewModelTests.cs
+++ b/SmartHomeMauiApp.Tests/MVVM/ViewModels/SettingsViewModelTests.cs
@@ -95,7 +95,7 @@ public class SettingsViewModelTests
         await _settingsViewModel.SaveSettingsAsync();
 
         // Assert
-        Assert.Equal("An error occurred while saving settings. Please try again.", _settingsViewModel.ResponseMessage);
+        Assert.Equal("An error occurred while saving settings. Please double check that your Iot-Hub connectionstring is valid.", _settingsViewModel.ResponseMessage);
         Assert.Equal("Red", _settingsViewModel.ResponseMessageColor);
     }
 }


### PR DESCRIPTION
The assertion message in the SettingsViewModelTests class has been updated for clarity. The previous message, "An error occurred while saving settings. Please try again.", has been replaced with a more specific message: "An error occurred while saving settings. Please double check that your Iot-Hub connectionstring is valid."